### PR TITLE
converted flowRoot to Text

### DIFF
--- a/writeaccess
+++ b/writeaccess
@@ -1,0 +1,1 @@
+How can I get writeaccess?


### PR DESCRIPTION
Converted unpubliced-flowRoot  to valid-SVG-1.1-DTD.
flowRoot cannot be rendered by common browsers or SVG-Viewer, since it uses a unpublished SVG-Version therfore convertet it to text.

inkscape ./${file}.svg --verb=EditSelectAll --verb=ObjectFlowtextToText --verb=FileSave --verb=FileClose --verb=FileQuit

using
https://github.com/JoKalliauer/cleanupSVG/blob/master/Flow2TextByInkscape.sh